### PR TITLE
Made the check to determine if two room names match more lenient.

### DIFF
--- a/google-calendar-interface/dist/index.js
+++ b/google-calendar-interface/dist/index.js
@@ -63,7 +63,7 @@ module.exports = function (req, res) { return __awaiter(_this, void 0, void 0, f
                         if (body.room === undefined) {
                             return true;
                         }
-                        return body.room.toLowerCase() === cal.summary.toLowerCase();
+                        return cal.summary.toLowerCase().includes(body.room.toLowerCase());
                     })
                         .map(function (cal) {
                         return requestEvents(CLIENT, cal);

--- a/google-calendar-interface/src/index.ts
+++ b/google-calendar-interface/src/index.ts
@@ -28,7 +28,7 @@ module.exports = async (req: HTTP.IncomingMessage, res: HTTP.ServerResponse) => 
                     return true
                 }
 
-                return body.room.toLowerCase() === cal.summary.toLowerCase()
+                return cal.summary.toLowerCase().includes(body.room.toLowerCase())
             })
             .map(cal => {
                 return requestEvents(CLIENT, cal)


### PR DESCRIPTION
As part of the move to 150 8th St, conference room summaries were
updated to include a street address, a capacity, and an equipment list.
Thus, the old check wasn't matching anymore.